### PR TITLE
Support 23.05

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
+    - uses: cachix/install-nix-action@v22
       with:
+        # Still 22.11 here because nix-linter is broken 23.05
         nix_path: nixpkgs=channel:nixos-22.11
     - run: ./lint.sh
 
@@ -18,5 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
-    - run: nix run home-manager/release-22.11 -- build --flake .#test
+    - uses: cachix/install-nix-action@v22
+    - run: mkdir -p ~/.local/state/nix/profiles # required as of 23.05 ; not sure why though...
+    - run: nix run home-manager/release-23.05 -- build --flake .#test

--- a/flake.lock
+++ b/flake.lock
@@ -55,25 +55,40 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "utils": "utils"
+        ]
       },
       "locked": {
-        "lastModified": 1685325875,
-        "narHash": "sha256-tevlLIMPeVNNYPd9UgjHApAUoFAnw9iohqUyj+LPp88=",
+        "lastModified": 1687871164,
+        "narHash": "sha256-bBFlPthuYX322xOlpJvkjUBz0C+MOBjZdDOOJJ+G2jU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b372d7f8d5518aaba8a4058a453957460481afbc",
+        "rev": "07c347bb50994691d7b0095f45ebd8838cf6bc38",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.11",
+        "ref": "release-23.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1689885880,
+        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-previous": {
       "locked": {
         "lastModified": 1688392541,
         "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
@@ -126,6 +141,7 @@
         "easy-purescript-nix": "easy-purescript-nix",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-previous": "nixpkgs-previous",
         "ptitfred-haddocset": "ptitfred-haddocset",
         "ptitfred-posix-toolbox": "ptitfred-posix-toolbox",
         "spago2nix": "spago2nix"
@@ -138,7 +154,7 @@
         ],
         "flake-utils": "flake-utils_2",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-previous"
         ]
       },
       "locked": {
@@ -167,21 +183,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,13 @@
 
   inputs = {
     # Specify the source of Home Manager and Nixpkgs.
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
     home-manager = {
-      url = "github:nix-community/home-manager/release-22.11";
+      url = "github:nix-community/home-manager/release-23.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    nixpkgs-previous.url = "github:nixos/nixpkgs/nixos-22.11";
 
     ptitfred-posix-toolbox = {
       url = "github:ptitfred/posix-toolbox";
@@ -23,7 +25,7 @@
 
     spago2nix = {
       url = "github:justinwoo/spago2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "nixpkgs-previous"; # FIXME get back to 23.05 once spago2nix drop nodejs-14
       inputs.easy-purescript-nix.follows = "easy-purescript-nix";
     };
   };
@@ -33,9 +35,13 @@
       system = "x86_64-linux";
 
       personal-overlay = self: _: {
+        # 22.11 still available when needed
+        previous = inputs.nixpkgs-previous.legacyPackages.${system};
+
         posix-toolbox = self.callPackage "${inputs.ptitfred-posix-toolbox}/nix/default.nix" {};
         haddocset = self.callPackage "${inputs.ptitfred-haddocset}/default.nix" {};
         postgresql_12_postgis = self.postgresql_12.withPackages (p: [ p.postgis ]);
+        nix-linter = self.previous.nix-linter;
       };
 
       purescript-overlay = _: _: {

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -100,10 +100,7 @@ in
       services = {
         polybar = {
           enable = true;
-          package = pkgs.polybar.override {
-            i3 = true;
-            i3GapsSupport = true;
-          };
+          package = pkgs.polybarFull;
           config = {
             "bar/main" = {
               font-0 = toPolybar roboto + ";2";
@@ -203,7 +200,6 @@ in
 
       xsession.windowManager.i3 = {
         enable = true;
-        package = pkgs.i3-gaps;
         config =
           let font = toGTK roboto;
               mkWorkspace = index: name: { inherit index name; };

--- a/home/development/haskell.nix
+++ b/home/development/haskell.nix
@@ -1,7 +1,8 @@
 { pkgs, lib, ... }:
 
 let check = name: assert (lib.asserts.assertMsg (pkgs.lib.attrsets.hasAttr name pkgs) "Missing ${name}"); name;
-    summoner = pkgs.haskellPackages.callPackage ./haskell/summoner-2.0.1.1.nix {};
+    # FIXME get back to 23.05 when summoner is updated
+    summoner = pkgs.previous.haskellPackages.callPackage ./haskell/summoner-2.0.1.1.nix {};
 in
 {
   home = {


### PR DESCRIPTION
- i3 and i3-gaps are now one and only (hopefully it's drop-n-replace)
- some packages are not yet supported in 23.05 and we'll fall back to 22.11 for those being late for now

Includes upgrade of github actions for nix mainly for [this](https://github.com/cachix/install-nix-action/releases/tag/v20).