### PR TITLE
Tooling: better nix linter utility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Test"
+name: "CI"
 on:
   pull_request:
   push:
@@ -11,9 +11,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v22
       with:
-        # Still 22.11 here because nix-linter is broken 23.05
-        nix_path: nixpkgs=channel:nixos-22.11
-    - run: ./lint.sh
+        nix_path: nixpkgs=channel:nixos-23.05
+    - run: nix run .#lint
 
   tests:
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689885880,
-        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
+        "lastModified": 1690148897,
+        "narHash": "sha256-l/j/AX1d2K79EWslwgWR2+htkzCbtjKZsS5NbWXnhz4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
+        "rev": "ac1acba43b2f9db073943ff5ed883ce7e8a40a2c",
         "type": "github"
       },
       "original": {
@@ -88,7 +88,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-previous": {
+    "previous": {
       "locked": {
         "lastModified": 1688392541,
         "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
@@ -141,7 +141,7 @@
         "easy-purescript-nix": "easy-purescript-nix",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-previous": "nixpkgs-previous",
+        "previous": "previous",
         "ptitfred-haddocset": "ptitfred-haddocset",
         "ptitfred-posix-toolbox": "ptitfred-posix-toolbox",
         "spago2nix": "spago2nix"
@@ -154,7 +154,7 @@
         ],
         "flake-utils": "flake-utils_2",
         "nixpkgs": [
-          "nixpkgs-previous"
+          "previous"
         ]
       },
       "locked": {

--- a/lint.nix
+++ b/lint.nix
@@ -1,0 +1,12 @@
+{ nix-linter
+, writeShellApplication
+}:
+
+writeShellApplication {
+  name = "lint";
+  runtimeInputs = [ nix-linter ];
+  text = ''
+    set -e
+    find . -type f -name "*.nix" -exec nix-linter {} + && echo "Everything is fine!"
+  '';
+}

--- a/lint.sh
+++ b/lint.sh
@@ -1,7 +1,0 @@
-#! /usr/bin/env nix-shell
-# shellcheck shell=bash
-#! nix-shell -i bash -p nix-linter
-
-set -e
-
-find . -type f -name "*.nix" -exec nix-linter {} \;


### PR DESCRIPTION
No more nix-shell and github actions can freely use latest nixpkgs as everything is pinned properly.