### PR TITLE
Screenshot utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONY:
 test:
 	nix run home-manager/release-23.05 -- build --flake .#test
+
+.PHONY:
+lint:
+	nix run .#lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY:
+test:
+	nix run home-manager/release-23.05 -- build --flake .#test

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -5,6 +5,9 @@ let lockCmd = "${pkgs.posix-toolbox.i3-screen-locker}/bin/i3-screen-locker";
 
     palette = import ./palette.nix;
 
+    screenshot = pkgs.callPackage ./desktop/screenshot.nix {};
+    screenshotCmd = "${screenshot}/bin/screenshot";
+
     inherit (import ./fonts.nix) roboto toPolybar toI3 toGTK;
 in
   {
@@ -256,7 +259,12 @@ in
                   mkBind = key: command: {
                     "${modifier}+${key}" = "exec ${command}";
                   };
-                  bindings = mkBind "comma" lockCmd // bindWorkspaces workspaces;
+                  mkBindRelease = key: command: {
+                    "--release ${modifier}+${key}" = "exec ${command}";
+                  };
+                  bindings = mkBind        "comma" lockCmd
+                          // mkBindRelease "x"     screenshotCmd
+                          // bindWorkspaces workspaces;
                in lib.mkOptionDefault bindings;
 
             menu = "${pkgs.bemenu}/bin/bemenu-run -l 20 -p '>' -i --fn '${font}' -H 15 --hf '${config.desktop.mainColor}' --tf '${config.desktop.mainColor}'";
@@ -285,9 +293,10 @@ in
                       (assignToWorkspace documentation [ { class = "^Zeal$";               } ])
                     ];
           };
-        extraConfig = ''
-          for_window [class=".*"] title_format "  %title"
-        '';
+        extraConfig =
+          ''
+            for_window [class=".*"] title_format "  %title"
+          '';
       };
 
       xresources.properties = with palette; {

--- a/home/desktop/screenshot.nix
+++ b/home/desktop/screenshot.nix
@@ -1,0 +1,10 @@
+{ writeShellApplication
+, scrot
+, xclip
+}:
+
+writeShellApplication {
+  name = "screenshot";
+  runtimeInputs = [ scrot xclip ];
+  text = builtins.readFile ./screenshot.sh;
+}

--- a/home/desktop/screenshot.sh
+++ b/home/desktop/screenshot.sh
@@ -1,0 +1,3 @@
+location="$HOME/Pictures/screenshots"
+mkdir -p "$location"
+scrot -s "$location/%Y-%m-%d_\$sx\$h.png" -e "xclip -sel c -t image/png \$f"


### PR DESCRIPTION
Configured to be launch on `Alt+x`, saves it in `$HOME/Pictures/screenshots` and copy in the clipboard as a `image/png` byte array (can be pasted in a navigator for instance, just like the one below):

![image](https://github.com/ptitfred/home-manager/assets/346377/1d7abd62-21e8-4ab3-aeba-06aca1b45314)
