### PR TITLE
i3/polybar: prepare support of physical machine

### DIFF
--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -66,6 +66,11 @@ in
         type = types.str;
         example = "ADP1";
       };
+
+      desktop.backlight.card = mkOption {
+        type = types.str;
+        default = "intel_backlight";
+      };
     };
 
     config = {
@@ -132,7 +137,7 @@ in
               radius = 4;
               width = "100%";
               modules-left = "i3";
-              modules-right = if config.desktop.virtual-machine then "memory date" else "memory battery date";
+              modules-right = if config.desktop.virtual-machine then "memory date" else "memory backlight battery date";
               background = "#99000000";
               padding = 3;
               border-size = config.desktop.spacing;
@@ -192,6 +197,21 @@ in
                   time-format = "%H:%M";
                   poll-interval = 2;
                   inherit (config.desktop.battery) full-at low-at battery adapter;
+                };
+                "module/backlight" = {
+                  type = "internal/backlight";
+                  inherit (config.desktop.backlight) card;
+                  enable-scroll = true;
+                  format = "<ramp> <bar>";
+                  bar-width = 5;
+                  bar-fill = "─";
+                  bar-empty = "─";
+                  bar-indicator = "|";
+                  ramp-0 = "🌕";
+                  ramp-1 = "🌔";
+                  ramp-2 = "🌓";
+                  ramp-3 = "🌒";
+                  ramp-4 = "🌑";
                 };
               }
             );

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -276,13 +276,11 @@ in
                 then
                   builtins.map onStart [
                     "systemctl --user restart polybar.service"
-                    "${pkgs.shutter}/bin/shutter --min_at_startup"
                   ]
                 else
                   builtins.map onStart [
                     "systemctl --user restart polybar.service"
                     "${pkgs.networkmanagerapplet}/bin/nm-applet"
-                    "${pkgs.shutter}/bin/shutter --min_at_startup"
                   ];
 
             assigns =

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -46,6 +46,26 @@ in
         description = "";
         default = 10;
       };
+
+      desktop.battery.full-at = mkOption {
+        type = types.int;
+        default = 99;
+      };
+
+      desktop.battery.low-at = mkOption {
+        type = types.int;
+        default = 10;
+      };
+
+      desktop.battery.battery = mkOption {
+        type = types.str;
+        example = "BAT1";
+      };
+
+      desktop.battery.adapter = mkOption {
+        type = types.str;
+        example = "ADP1";
+      };
     };
 
     config = {
@@ -112,7 +132,7 @@ in
               radius = 4;
               width = "100%";
               modules-left = "i3";
-              modules-right = "memory date";
+              modules-right = if config.desktop.virtual-machine then "memory date" else "memory battery date";
               background = "#99000000";
               padding = 3;
               border-size = config.desktop.spacing;
@@ -158,7 +178,23 @@ in
               time = "%H:%M:%S";
               label = "%date%  %time%";
             };
-          };
+          } // (
+            if config.desktop.virtual-machine
+            then {}
+            else
+              {
+                "module/battery" = {
+                  type = "internal/battery";
+                  label-charging    =   "~ %percentage%% (%time% +%consumption%W)";
+                  label-discharging =     "%percentage%% (%time% -%consumption%W)";
+                  label-low         = "!!! %percentage%% (%time% -%consumption%W)";
+                  label-full = "Max";
+                  time-format = "%H:%M";
+                  poll-interval = 2;
+                  inherit (config.desktop.battery) full-at low-at battery adapter;
+                };
+              }
+            );
           script = "polybar main &";
         };
 

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -296,6 +296,7 @@ in
         extraConfig =
           ''
             for_window [class=".*"] title_format "  %title"
+            exec i3-msg workspace 1
           '';
       };
 

--- a/home/desktop.nix
+++ b/home/desktop.nix
@@ -144,6 +144,7 @@ in
               border-top-size = if bottom then 0 else config.desktop.spacing;
               border-bottom-size = if bottom then config.desktop.spacing else 0;
               separator = "|";
+              separator-foreground = config.desktop.mainColor;
               module-margin = 2;
               locale = "fr_FR.UTF-8";
               tray-position = "center";

--- a/tests/home.nix
+++ b/tests/home.nix
@@ -2,6 +2,7 @@
 
 {
   desktop = {
+    virtual-machine = true;
     mainColor = "#FF0000";
     location = { latitude = "44.0003"; longitude = "4.20001"; };
     spacing = 10;


### PR DESCRIPTION
## Rationale

This PR extends polybar and i3 configuration to make it usable on a physical machine where you need to control physical parts of the setup (in contrary to a virtual machine where the host handles it).

## Changes

- [i3: Adjust startup commands](https://github.com/ptitfred/home-manager/commit/ce3dd0b20bc9a0abd4f9a60dbea0c4843fe4867b)
  - Starts VBoxClient on vms as it's not properly started for now.
  - Stop starting Shutter as it's actually totally broken. The custom
    script bound on `Mod+s` can be used instead.
- [polybar: Add battery module](https://github.com/ptitfred/home-manager/commit/d85f7398c65a65b8b4a79ed77228b4666ebc3d5c)
- [polybar: Add backlight module](https://github.com/ptitfred/home-manager/commit/9a41fff8b004bc7b9ecc6d6ff98f274851c62e2e)

## Bonus changes

- [i3: workspace 1 as default](https://github.com/ptitfred/home-manager/commit/fd0c839468aec4bb7db0a036359314c400f63bc5)
- [polybar: Unify separator's style](https://github.com/ptitfred/home-manager/commit/0650e0362dfb8ae210262fd510fee4d04a702b5e)