### PR TITLE
terminal: Add emojis support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690148897,
-        "narHash": "sha256-l/j/AX1d2K79EWslwgWR2+htkzCbtjKZsS5NbWXnhz4=",
+        "lastModified": 1690927903,
+        "narHash": "sha256-D5gCaCROnjEKDOel//8TO/pOP87pAEtT0uT8X+0Bj/U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ac1acba43b2f9db073943ff5ed883ce7e8a40a2c",
+        "rev": "bd836ac5e5a7358dea73cb74a013ca32864ccb86",
         "type": "github"
       },
       "original": {

--- a/home/development/shell.nix
+++ b/home/development/shell.nix
@@ -52,9 +52,14 @@ let baseSize = config.desktop.fontSize;
 
     urxvt = {
       enable = true;
-      fonts = [
-        (toXFT { name = "Monospace"; size = baseSize +1; })
-      ];
+      package = pkgs.rxvt-unicode-emoji;
+      fonts =
+        let f = name: toXFT { inherit name; size = baseSize + 1; };
+         in map f
+              [
+                "Monospace"
+                "Material Symbols Outlined"
+              ];
       keybindings = {
         "Shift-Control-C" = "eval:selection_to_clipboard";
         "Shift-Control-V" = "eval:paste_clipboard";


### PR DESCRIPTION
The key part though was to use the `rxvt-unicode-emojis` packet to fix the core issues of rendering. I'd wish the [home-manager urxvt package](https://nix-community.github.io/home-manager/options.html#opt-programs.urxvt.enable) would have been hinting at it in the first place :/