### PR TITLE
Workaround to Zeal's TLS certificate expired

### DIFF
--- a/home/development/tools.nix
+++ b/home/development/tools.nix
@@ -1,5 +1,12 @@
 { pkgs, ... }:
 
+let # See https://github.com/zealdocs/zeal/issues/1518#issuecomment-1661587539
+    faketimed-zeal = pkgs.writeShellApplication {
+      name = "zeal";
+      runtimeInputs = [ pkgs.libfaketime pkgs.zeal ];
+      text = "faketime '2023-07-26 00:00:00' zeal";
+    };
+in
 {
   home.packages = with pkgs; [
     gnumake
@@ -7,6 +14,6 @@
     jq
     shellcheck
     posix-toolbox.wait-tcp
-    zeal
+    faketimed-zeal
   ];
 }


### PR DESCRIPTION
See https://github.com/zealdocs/zeal/issues/1518. This workaround is quite dirty...