### PR TITLE
polybar/github: open notifications on click

### DIFF
--- a/home/desktop/browse/default.nix
+++ b/home/desktop/browse/default.nix
@@ -1,0 +1,13 @@
+{ writeShellApplication
+, xdg-utils
+, profile
+}:
+
+writeShellApplication {
+  name = "browse";
+  runtimeInputs = [ xdg-utils ];
+  text = ''
+    export PATH=${profile}/bin:$PATH
+    xdg-open "$@"
+  '';
+}

--- a/home/desktop/polybar.nix
+++ b/home/desktop/polybar.nix
@@ -18,6 +18,9 @@ let bottom = true;
     editConnectionsOnClick = onClick "${pkgs.networkmanagerapplet}/bin/nm-connection-editor";
     monitorOnClick         = onClick (focus "^Com.github.stsdc.monitor$" "${pkgs.monitor}/bin/com.github.stsdc.monitor");
 
+    browse = pkgs.callPackage ./browse { profile = "${config.home.homeDirectory}/.nix-profile"; };
+    browseOnClick = url: onClick "${browse}/bin/browse ${builtins.replaceStrings [":"] ["\\\\:"] url}";
+
     onClick = program: label:
       "%{A1:${program}:}${label}%{A}";
 
@@ -187,7 +190,7 @@ in
           empty-notifications = false;
           interval = 10;
 
-          label = "%{T3}%{T-} %notifications%";
+          label = browseOnClick "https://github.com/notifications" "%{T3}%{T-} %notifications%";
 
           label-offline = {
             text = "%{T3}%{T-} hors ligne";

--- a/home/desktop/polybar.nix
+++ b/home/desktop/polybar.nix
@@ -190,10 +190,10 @@ in
           empty-notifications = false;
           interval = 10;
 
-          label = browseOnClick "https://github.com/notifications" "%{T3}%{T-} %notifications%";
+          label = browseOnClick "https://github.com/notifications" "%{T3}%{T-}  %notifications%";
 
           label-offline = {
-            text = "%{T3}%{T-} hors ligne";
+            text = "%{T3}%{T-}  hors ligne";
             foreground = config.desktop.disabledColor;
           };
         };


### PR DESCRIPTION
xdg-open is crawling the PATH and the basic polybar systemd service doesn't provide it with the correct PATH (for xdg-open to locate firefox). This PR includes a direct patch to achieve it.