### PR TITLE
Neovim: fix airline

### DIFF
--- a/home/development/neovim-config.vim
+++ b/home/development/neovim-config.vim
@@ -1,5 +1,7 @@
 colorscheme gruvbox
 
+let g:airline_powerline_fonts = 1
+
 set tabstop=2
 set shiftwidth=2
 

--- a/home/development/patched-monospace.nix
+++ b/home/development/patched-monospace.nix
@@ -1,0 +1,16 @@
+{ runCommand
+, dejavu_fonts
+, nerd-font-patcher
+}:
+
+# FIXME: I've tried including the material-symbols glyphs but FontForge coredump
+runCommand "patched-monospace" {
+  buildInputs = [ nerd-font-patcher ];
+} ''
+  mkdir -p $out/share/fonts/truetype
+  nerd-font-patcher --outputdir $out/share/fonts/truetype \
+    --mono \
+    --fontawesome --fontawesomeextension \
+    --powerline --powerlineextra \
+    ${dejavu_fonts}/share/fonts/truetype/DejaVuSansMono.ttf
+''

--- a/home/development/shell.nix
+++ b/home/development/shell.nix
@@ -2,6 +2,7 @@
 
 let baseSize = config.desktop.fontSize;
     inherit (import ../fonts.nix { inherit baseSize; }) toXFT;
+    patched-monospace = pkgs.callPackage ./patched-monospace.nix {};
  in
 
 {
@@ -11,6 +12,7 @@ let baseSize = config.desktop.fontSize;
       file
       tree
       noto-fonts-emoji
+      patched-monospace
     ];
 
     sessionVariables = {
@@ -58,7 +60,7 @@ let baseSize = config.desktop.fontSize;
         let f = name: toXFT { inherit name; size = baseSize + 1; };
          in map f
               [
-                "Monospace"
+                "DejaVuSansM Nerd Font Mono Plus Font Awesome Plus Font Awesome Extension"
                 "Material Symbols Outlined"
                 "Noto Color Emoji"
               ];


### PR DESCRIPTION
Let's change the default monospace font with a patched one and make sure the vim-airline plugin actually enable the proper glyphs. It should be more straightforward, but now it's finally fixed:

![image](https://github.com/ptitfred/home-manager/assets/346377/495773d0-1840-451e-af63-eb87181dab57)
