### PR TITLE
Bump nixpkgs & HM to 23.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "flake-utils": "flake-utils"
       },
       "locked": {
-        "lastModified": 1689933391,
-        "narHash": "sha256-jUuy2OzmxegEn0KT3u1uf87eGGA33+of9HodIqS3PLY=",
+        "lastModified": 1696584097,
+        "narHash": "sha256-a9Hhqf/Fi0FkjRTcQr3pYDhrO9A9tdOkaeVgD23Cdrk=",
         "owner": "justinwoo",
         "repo": "easy-purescript-nix",
-        "rev": "5dcea83eecb56241ed72e3631d47e87bb11e45b9",
+        "rev": "d5fe5f4b210a0e4bac42ae0c159596a49c5eb016",
         "type": "github"
       },
       "original": {
@@ -58,16 +58,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1687871164,
-        "narHash": "sha256-bBFlPthuYX322xOlpJvkjUBz0C+MOBjZdDOOJJ+G2jU=",
+        "lastModified": 1703367386,
+        "narHash": "sha256-FMbm48UGrBfOWGt8+opuS+uLBLQlRfhiYXhHNcYMS5k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07c347bb50994691d7b0095f45ebd8838cf6bc38",
+        "rev": "d5824a76bc6bb93d1dce9ebbbcb09a9b6abcc224",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -90,16 +90,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691155011,
-        "narHash": "sha256-O15tC0ysw+fcacEbOzrDrkVNIR+SgtArSGvpgsEqpvA=",
+        "lastModified": 1703467016,
+        "narHash": "sha256-/5A/dNPhbQx/Oa2d+Get174eNI3LERQ7u6WTWOlR1eQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9652a97d9738d3e65cf33c0bc24429e495a7868f",
+        "rev": "d02d818f22c777aa4e854efc3242ec451e5d462a",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -123,11 +123,11 @@
     "power-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1667959628,
-        "narHash": "sha256-ar3nNX2VGlpewCHKBruBm1eyksx8kSUenxl7xoWbT5w=",
+        "lastModified": 1699434176,
+        "narHash": "sha256-HOUnLm2GSvJkCxK9ofM5p2I9xpF6Se44/8a/bkwrnmw=",
         "owner": "wfxr",
         "repo": "tmux-power",
-        "rev": "9dafd5b0504906421f904149b178c1ddb83a0580",
+        "rev": "1d73c304573b3ae369567d2ef635f0e1c3de7ecc",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671225584,
-        "narHash": "sha256-h9r67pmvDuA3TV9299L4CN60XSm8RRtX1EwUoKu9Pyw=",
+        "lastModified": 1696845391,
+        "narHash": "sha256-l/uUg0mxh9HVCPcciMlFt2xk6Ue/qOP9TSgLp9g4EPk=",
         "owner": "justinwoo",
         "repo": "spago2nix",
-        "rev": "1b8ec352bc7eac077b934d6b9f6efa0129926e59",
+        "rev": "f8712693764f318d61123e1c9eac6b37ef4ca270",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,9 @@
 
   inputs = {
     # Specify the source of Home Manager and Nixpkgs.
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
     home-manager = {
-      url = "github:nix-community/home-manager/release-23.05";
+      url = "github:nix-community/home-manager/release-23.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/home/development/purescript.nix
+++ b/home/development/purescript.nix
@@ -5,7 +5,7 @@
     packages = with pkgs; [
       purescript
       purescript-psa
-      spago
+      easy-ps.spago
       spago2nix
       easy-ps.purty
     ];

--- a/home/others.nix
+++ b/home/others.nix
@@ -1,8 +1,8 @@
 { pkgs, lib, ... }:
 
 let obsidian = pkgs.callPackage ./obsidian.nix {
-      version = "1.3.7";
-      sha256 = "sha256-8Qi12d4oZ2R6INYZH/qNUBDexft53uy9Uug7UoArwYw=";
+      version = "1.5.3";
+      sha256 = "sha256-F7nqWOeBGGSmSVNTpcx3lHRejSjNeM2BBqS9tsasTvg=";
     };
 in
 {
@@ -19,4 +19,9 @@ in
 
   # Necessary for flakes, see https://github.com/nix-community/home-manager/issues/2942#issuecomment-1119760100
   nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "slack" "obsidian" ];
+
+  # Electron version 25.9.0 is EOL but is used by obsidian.
+  nixpkgs.config.permittedInsecurePackages = [
+    "electron-25.9.0"
+  ];
 }

--- a/justfile
+++ b/justfile
@@ -4,8 +4,8 @@ help:
 
 # Test various home-manager configurations
 test:
-  nix run home-manager/release-23.05 -- build --flake .#test-virtual-machine
-  nix run home-manager/release-23.05 -- build --flake .#test-laptop
+  nix run home-manager/release-23.11 -- build --flake .#test-virtual-machine
+  nix run home-manager/release-23.11 -- build --flake .#test-laptop
 
 # Lint nix files
 lint:


### PR DESCRIPTION
Changes:
- `spago` is no longer built in nixpkgs and I chose to use the one provided by easy-purescript. It's a band-aid anyway and probably should we no longer have such tools provided globally as it's brings confusion when hacking around a given project (due to versions mismatch)
- `obsidian` updated (not required but it was the occasion)
- `electron-25.9.0` acknowledged as "insecure" (for obsidian). Let's hope obsidian bumps its dependencies sooner than later